### PR TITLE
Fix api date query param

### DIFF
--- a/jobvite.py
+++ b/jobvite.py
@@ -72,7 +72,7 @@ class JobviteAPI:
         """
         params = params.copy()
         if modified_date:
-            params["startdate"] = modified_date
+            params["datestart"] = modified_date
             params["dateFormat"] = "yyyy-MM-dd"
 
         params["count"] = batch_size


### PR DESCRIPTION
Quick fix for the datestart param in the jobvite API call.