### PR TITLE
DATA-1512 Set candidate start date to null if it doesn't exist

### DIFF
--- a/candidate.py
+++ b/candidate.py
@@ -46,6 +46,8 @@ class Candidate:
             self.startDate = self._convert_datetime(
                 application.get("startDate")
             )
+        else:
+            self.startDate = None
         for field in data_config.application_fields:
             value = self._remove_whitespace(application.get(field, ""))
             setattr(self, field, value)


### PR DESCRIPTION
If there were no candidates in the batch with a start date, then the column wasn't being created in the DF, which was causing the error.