### PR TITLE
Update Jobvite Credential Authorization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sou
 RUN apt-get update
 RUN apt-get install -y apt-utils
 RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17
+RUN apt-get install -y unixodbc unixodbc-dev
 RUN pip install pipenv
 RUN pipenv install
 COPY ./*.py /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ COPY ./.env /app/
 COPY ./Pipfile* /app/
 COPY dept_codes.csv /app/
 RUN mkdir output
-RUN wget https://packages.microsoft.com/debian/10/prod/pool/main/m/msodbcsql17/msodbcsql17_17.9.1.1-1_amd64.deb
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/debian/9/prod.list > /etc/apt/sources.list.d/mssql-release.list
 RUN apt-get update
 RUN apt-get install -y apt-utils
-RUN apt-get install -y unixodbc unixodbc-dev
+RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17
 RUN pip install pipenv
 RUN pipenv install
-RUN yes | dpkg -i msodbcsql17_17.9.1.1-1_amd64.deb
 COPY ./*.py /app/
 ENTRYPOINT ["pipenv", "run", "python", "main.py"]
  

--- a/jobvite.py
+++ b/jobvite.py
@@ -24,8 +24,8 @@ class JobviteAPI:
         self.logger = logger if logger else logging.getLogger()
 
     @property
-    def default_request_params(self):
-        return {"api": self.api_key, "sc": self.api_secret}
+    def request_credentials(self):
+        return {"x-jvi-api": self.api_key, "x-jvi-sc": self.api_secret}
 
     @property
     def candidates_endpoint(self):
@@ -41,7 +41,8 @@ class JobviteAPI:
             'requesting: "{}?{}"'.format(endpoint, urlencode(params, doseq=True))
         )
 
-        response = requests.get(endpoint, params=params)
+        # As of 10/1/2023, credentials have to be passed through headers
+        response = requests.get(endpoint, params=params, headers=self.request_credentials)
         if response.status_code == 200:
             return response
         else:

--- a/jobvite.py
+++ b/jobvite.py
@@ -41,10 +41,6 @@ class JobviteAPI:
             'requesting: "{}?{}"'.format(endpoint, urlencode(params, doseq=True))
         )
 
-        for k, v in self.default_request_params.items():
-            if k not in params:
-                params[k] = v
-
         response = requests.get(endpoint, params=params)
         if response.status_code == 200:
             return response


### PR DESCRIPTION
Starting October 1st 2023, Jobvite will no longer permit API keys and secrets to be passed through the URL. These will need to be passed through the request headers. This PR updates the the repo to comply with this. 

This PR also updates how msodbc is installed in Docker. The past way of installing msodbc had started failing for some reason.